### PR TITLE
Fix Mediamarkt Captcha detection

### DIFF
--- a/src/store/model/mediamarkt.ts
+++ b/src/store/model/mediamarkt.ts
@@ -5,7 +5,7 @@ export const Mediamarkt: Store = {
   currency: '€',
   labels: {
     captcha: {
-      container: 'p',
+      container: 'body',
       text: ['Das ging uns leider zu schnell.'],
     },
     maxPrice: {


### PR DESCRIPTION
the captcha text was located in the second <p> on the site and the captcha check seems only to look in the first element it finds.

<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
